### PR TITLE
Task/get all products updates for card usage

### DIFF
--- a/API/Controllers/ProductController.cs
+++ b/API/Controllers/ProductController.cs
@@ -27,9 +27,9 @@ namespace API.Controllers
 
         [HttpGet]
         [Route("GetProducts")]
-        public async Task<IActionResult> GetAllProducts()
+        public async Task<IActionResult> GetAllProducts([FromQuery] GetAllProductsQuery query)
         {
-            return Ok(await mediatr.Send(new GetAllProductsQuery()));
+            return Ok(await mediatr.Send(query));
         }
 
         [HttpGet]

--- a/Application/DTOs/Product/FullProductDTO.cs
+++ b/Application/DTOs/Product/FullProductDTO.cs
@@ -1,0 +1,21 @@
+﻿using Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dom = Domain.Models;
+
+namespace Application.DTOs.Product
+{
+    public class FullProductDTO
+    {
+        public Dom.Product? Product { get; set; }
+        public Dom.ProductDetail? ProductDetail { get; set; }
+        public FullProductDTO(Dom.Product? productBase, ProductDetail? productDetail)
+        {
+            Product = productBase;
+            ProductDetail = productDetail;
+        }
+    }
+}

--- a/Application/Queries/ProductQueries/GetAllProducts/GetAllProductsQuery.cs
+++ b/Application/Queries/ProductQueries/GetAllProducts/GetAllProductsQuery.cs
@@ -6,7 +6,7 @@ namespace Application.Queries.ProductQueries.GetAllProducts
 {
     public class GetAllProductsQuery : IRequest<OperationResult<IEnumerable<Product>>>
     {
-        public int PageNumber { get; set; } = 1;
-        public int PageSize { get; set; } = 10;
+        public int Page { get; set; } = 1;
+        public int Hits { get; set; } = 10;
     }
 }

--- a/Application/Queries/ProductQueries/GetAllProducts/GetAllProductsQueryHandler.cs
+++ b/Application/Queries/ProductQueries/GetAllProducts/GetAllProductsQueryHandler.cs
@@ -20,16 +20,16 @@ namespace Application.Queries.ProductQueries.GetAllProducts
         }
         public async Task<OperationResult<IEnumerable<Product>>> Handle(GetAllProductsQuery request, CancellationToken cancellationToken)
         {
-            var page = request.PageNumber;
-            var size = request.PageSize;
+            var page = request.Page;
+            var size = request.Hits;
 
             var cacheKey = $"Products_p{page}_s{size}";
             try
             {
                 if (!memoryCache.TryGetValue(cacheKey, out IEnumerable<Product>? products))
                 {
-                    products = await database.GetPageAsync(page, size, cancellationToken);
-                    memoryCache.Set(cacheKey, products, TimeSpan.FromMinutes(5));
+                    products = await database.GetPageAsync(page, size, cancellationToken);  // Potentially Automap this later to only sendback cardDTO
+                    memoryCache.Set(cacheKey, products, TimeSpan.FromMinutes(1));
                     logger.LogInformation($"Cache miss. Fetched products for page:{page} with size:{size} from database and cached at {DateTime.UtcNow}");
                 }
                 else

--- a/Application/Queries/ProductQueries/GetAllProducts/GetAllProductsQueryHandler.cs
+++ b/Application/Queries/ProductQueries/GetAllProducts/GetAllProductsQueryHandler.cs
@@ -28,7 +28,7 @@ namespace Application.Queries.ProductQueries.GetAllProducts
             {
                 if (!memoryCache.TryGetValue(cacheKey, out IEnumerable<Product>? products))
                 {
-                    products = await database.GetPageAsync(page, size, cancellationToken);  // Potentially Automap this later to only sendback cardDTO
+                    products = await database.GetPageAsync(page, size, cancellationToken);
                     memoryCache.Set(cacheKey, products, TimeSpan.FromMinutes(1));
                     logger.LogInformation($"Cache miss. Fetched products for page:{page} with size:{size} from database and cached at {DateTime.UtcNow}");
                 }

--- a/Application/Queries/ProductQueries/GetProductById/GetProductByIdQuery.cs
+++ b/Application/Queries/ProductQueries/GetProductById/GetProductByIdQuery.cs
@@ -1,10 +1,11 @@
-﻿using Application.Helpers;
+﻿using Application.DTOs.Product;
+using Application.Helpers;
 using Domain.Models;
 using MediatR;
 
 namespace Application.Queries.ProductQueries.GetProductById
 {
-    public class GetProductByIdQuery : IRequest<OperationResult<Product?>>
+    public class GetProductByIdQuery : IRequest<OperationResult<FullProductDTO?>>
     {
         public int Id { get; set; }
         public GetProductByIdQuery(int id)

--- a/Domain/Models/ProductDetail.cs
+++ b/Domain/Models/ProductDetail.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Models
+{
+    public class ProductDetail
+    {
+        [Key]
+        public int Id { get; set; }
+        [ForeignKey("Product")]
+        public int ProductId { get; set; }
+    }
+}

--- a/Infrastructure/Database/RealDatabase.cs
+++ b/Infrastructure/Database/RealDatabase.cs
@@ -8,6 +8,7 @@ namespace Infrastructure.Database
         public RealDatabase(DbContextOptions<RealDatabase> options) : base(options) { }
         public DbSet<User> Users { get; set; }
         public DbSet<Product> Products { get; set; }
+        public DbSet<ProductDetail> ProductDetail { get; set; }
         //public DbSet<Author> Authors { get; set; }
         //public DbSet<Book> Books { get; set; }
     }


### PR DESCRIPTION
Added another domain item called ProductDetail. it should contain details of a specific product allowing use to query for detail specifically using GetProductById.
My thought process is that we can use GetAllProductsQuery as a minimal info get all for cards in a gallery etc. GetProductById also queries for ProductDetail in our database and combines them in a FullProductDTO. I tested it and it seemed to work.

Make sure you update your own database.
The classes should be expanded later when seedhelper is implemented